### PR TITLE
correct HRworks support email address

### DIFF
--- a/articles/active-directory/saas-apps/hrworks-single-sign-on-tutorial.md
+++ b/articles/active-directory/saas-apps/hrworks-single-sign-on-tutorial.md
@@ -105,7 +105,7 @@ To configure Azure AD single sign-on with HRworks Single Sign-On, perform the fo
     `https://login.hrworks.de/?companyId=<companyId>&directssologin=true`
 
 	> [!NOTE]
-	> The value is not real. Update the value with the actual Sign-On URL. Contact [HRworks Single Sign-On Client support team](mailto:nadja.sommerfeld@hrworks.de) to get the value. You can also refer to the patterns shown in the **Basic SAML Configuration** section in the Azure portal.
+	> The value is not real. Update the value with the actual Sign-On URL. Contact [HRworks Single Sign-On Client support team](mailto:support@hrworks.de) to get the value. You can also refer to the patterns shown in the **Basic SAML Configuration** section in the Azure portal.
 
 5. On the **Set up Single Sign-On with SAML** page, in the **SAML Signing Certificate** section, click **Download** to download the **Federation Metadata XML** from the given options as per your requirement and save it on your computer.
 


### PR DESCRIPTION
Replaced the HRworks support email address with the correct one: support@hrworks.de